### PR TITLE
Feature/fix blog scaffold config

### DIFF
--- a/lib/generators/blog/templates/blog/.vuepress/config.js
+++ b/lib/generators/blog/templates/blog/.vuepress/config.js
@@ -5,11 +5,8 @@ module.exports = {
   themeConfig: {
     /**
      * Ref: https://vuepress-theme-blog.ulivz.com/#modifyblogpluginoptions
-     * Workaround of https://github.com/ulivz/vuepress-plugin-blog/issues/1
      */
     modifyBlogPluginOptions(blogPlugnOptions) {
-      const archiveDirectoryClassifierIndex = blogPlugnOptions.directories.findIndex(d => d.id === 'archive')
-      blogPlugnOptions.directories.splice(archiveDirectoryClassifierIndex, 1)
       return blogPlugnOptions
     },
     /**

--- a/lib/generators/blog/templates/blog/.vuepress/config.js
+++ b/lib/generators/blog/templates/blog/.vuepress/config.js
@@ -6,8 +6,8 @@ module.exports = {
     /**
      * Ref: https://vuepress-theme-blog.ulivz.com/#modifyblogpluginoptions
      */
-    modifyBlogPluginOptions(blogPlugnOptions) {
-      return blogPlugnOptions
+    modifyBlogPluginOptions(blogPluginOptions) {
+      return blogPluginOptions
     },
     /**
      * Ref: https://vuepress-theme-blog.ulivz.com/#nav


### PR DESCRIPTION
I was confused when I used blog scaffold for first time. Although some example articles was already contained in `_posts` folder,  I could't view any posts but 404.

I'm not sure whether the [issue](https://github.com/ulivz/vuepress-plugin-blog/issues/1) has been solved or not, but I believe the code below cause error:
```JavaScript
// config.js
// ...
    /**
     * Ref: https://vuepress-theme-blog.ulivz.com/#modifyblogpluginoptions
     * Workaround of https://github.com/ulivz/vuepress-plugin-blog/issues/1
     */
    modifyBlogPluginOptions(blogPlugnOptions) {
      const archiveDirectoryClassifierIndex = blogPlugnOptions.directories.findIndex(d => d.id === 'archive')
      blogPlugnOptions.directories.splice(archiveDirectoryClassifierIndex, 1)
      return blogPlugnOptions
    },
// ...
```
I can't see any object with id  'archive' in source code:
```JavaScript
// theme-blog/index.js
  const defaultBlogPluginOptions = {
    directories: [
      {
        id: 'post',
        dirname: '_posts',
        path: '/',
        // layout: 'IndexPost', defaults to `Layout.vue`
        itemLayout: 'Post',
        itemPermalink: '/:year/:month/:day/:slug',
        pagination: {
          lengthPerPage: 5,
        },
      },
    ],
    frontmatters: [
      {
        id: "tag",
        keys: ['tag', 'tags'],
        path: '/tag/',
        // layout: 'Tag',  defaults to `FrontmatterKey.vue`
        frontmatter: { title: 'Tag' },
        pagination: {
          lengthPerPage: 5
        }
      },
    ]
```