### PR TITLE
fix: update generator prompt message

### DIFF
--- a/lib/generators/blog/index.js
+++ b/lib/generators/blog/index.js
@@ -22,7 +22,7 @@ class Generator extends BasicGenerator {
 			},
 			{
 				name: 'repo',
-				message: `What's the repo of your project.`
+				message: `What's the repo of your project?`
 			}
 		];
 		return this.prompt(prompts).then(props => {

--- a/lib/generators/docs/index.js
+++ b/lib/generators/docs/index.js
@@ -22,7 +22,7 @@ class Generator extends BasicGenerator {
 			},
 			{
 				name: 'repo',
-				message: `What's the repo of your project.`
+				message: `What's the repo of your project?`
 			}
 		];
 		return this.prompt(prompts).then(props => {


### PR DESCRIPTION
Minor update in the generator prompt message.

This will add a `?` at the end of the last question (_What's the repo of your project_) to follow the pattern used in all the rest of the prompt messages during project generation.